### PR TITLE
Add QML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ And light:
 
 ## Navigation
 
-- [Navigation](#navigation)
-- [Build](#build)
-- [Getting started](#getting-started)
-- [Run examples](#run-examples)
-- [Future Plans](#future-plans)
-- [License information](#license-information)
-- [Credits](#credits)
-- [Donation](#donation)
+- [Qt-Advanced-Stylesheets](#qt-advanced-stylesheets)
+  - [Navigation](#navigation)
+  - [Build](#build)
+  - [Getting started](#getting-started)
+  - [Run examples](#run-examples)
+  - [Usage in QML](#usage-in-qml)
+  - [Future Plans](#future-plans)
+  - [License information](#license-information)
+  - [Credits](#credits)
+  - [Donation](#donation)
 
 ## Build
 
@@ -82,6 +84,43 @@ themes and create new ones.
 
 ![theme](doc/theme.gif)
 
+## Usage in QML
+This project can also be used with QML applications. In addition to the steps 
+described in the [previous paragraph](#getting-started) you need to register the 
+provided `CQmlStyleUrlInterceptor` to the QML Engine you're using.
+
+Let's say you have your `CStyleManager` instance and a `QQuickWidget` that 
+displays your QML content. The only thing you need to do now is the following:
+```cpp
+acss::CStyleManager* StyleManager = new acss::CStyleManager;
+
+QQuickWidget Widget;
+Widget.engine()->setUrlInterceptor(new CQmlStyleUrlInterceptor(StyleManager));
+```
+
+And that's it. Now you can use all of the icons provided by the style manager as
+you would in your C++ code:
+```qml
+CheckBox {
+    id: checkBox
+
+    indicator: Rectangle {
+        implicitHeight: 26
+        implicitWidth: 26
+        x: checkBox.leftPadding
+        y: checkBox.height / 2 - height / 2
+        Image {
+            source: checkBox.checked ? "icon:/primary/checkbox_checked.svg" :
+                                        "icon:/primary/checkbox_unchecked.svg"
+            // Important: Disable caching because otherwise you won't see any changes
+            cache: false
+        }
+    }
+}
+```
+
+Check the `full_features` example to see this in action.
+
 ## Future Plans
 
 The idea is to merge my [QtFluentDesign](https://github.com/githubuser0xFFFF/QtFluentDesign) project into this project to create a nice Windows 11 style that can dynamically
@@ -93,7 +132,7 @@ adapt to the Windows accent color and to the Window dark and light theme.
 
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](gnu-lgpl-v2.1.md)
 This project uses the [LGPLv2.1 license](gnu-lgpl-v2.1.md) for the source code.
-The stylesheets use individal licenses which are located in the directory of
+The stylesheets use individual licenses which are located in the directory of
 the corresponding style.
 
 ## Credits
@@ -101,7 +140,7 @@ the corresponding style.
 - Uwe Kindler, Project Maintainer
 - [GCPDS](https://github.com/UN-GCPDS) - Grupo de control y procesamiento digital de señales
 
-The project is strongy inspired by the great [Qt-material](https://github.com/UN-GCPDS/qt-material) project from [GCPDS](https://github.com/UN-GCPDS) and uses the qt-material stylesheet from this project.
+The project is strongly inspired by the great [Qt-material](https://github.com/UN-GCPDS/qt-material) project from [GCPDS](https://github.com/UN-GCPDS) and uses the qt-material stylesheet from this project.
 
 ## Donation
 

--- a/examples/full_features/full_features.pro
+++ b/examples/full_features/full_features.pro
@@ -1,6 +1,6 @@
 ACSS_OUT_ROOT = $${OUT_PWD}/../..
 
-QT += core gui widgets
+QT += core gui widgets quickwidgets qml
 
 CONFIG += c++14
 CONFIG += debug_and_release
@@ -20,7 +20,7 @@ HEADERS += \
 
 FORMS += \
     mainwindow.ui
-    
+
 RESOURCES += full_features.qrc
 
 DEFINES += "STYLES_DIR=$$PWD/../../styles"
@@ -29,4 +29,7 @@ DEFINES += "STYLES_DIR=$$PWD/../../styles"
 LIBS += -L$${ACSS_OUT_ROOT}/lib
 include(../../acss.pri)
 INCLUDEPATH += ../../src
-DEPENDPATH += ../../src  
+DEPENDPATH += ../../src
+
+DISTFILES += \
+    qml/simple_demo.qml

--- a/examples/full_features/full_features.qrc
+++ b/examples/full_features/full_features.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/full_features">
         <file>images/logo_frame.svg</file>
+        <file>qml/simple_demo.qml</file>
     </qresource>
 </RCC>

--- a/examples/full_features/mainwindow.cpp
+++ b/examples/full_features/mainwindow.cpp
@@ -1,8 +1,9 @@
-#include "mainwindow.h"
+#include "MainWindow.h"
 
 #include <StyleManager.h>
+#include <QmlStyleUrlInterceptor.h>
 
-#include "ui_mainwindow.h"
+#include "ui_MainWindow.h"
 #include <QDir>
 #include <QApplication>
 #include <QAction>
@@ -12,6 +13,7 @@
 #include <QPushButton>
 #include <QColorDialog>
 #include <QDebug>
+#include <QQmlEngine>
 
 #include <iostream>
 
@@ -37,7 +39,9 @@ struct MainWindowPrivate
 	void createThemeColorDockWidget();
 	void fillThemeMenu();
 	void setSomeIcons();
+	void setupQuickWidget();
 	void updateThemeColorButtons();
+	void updateQuickWidget();
 };
 
 
@@ -79,6 +83,16 @@ void MainWindowPrivate::updateThemeColorButtons()
 }
 
 
+void MainWindowPrivate::updateQuickWidget()
+{
+	const auto Source = ui.quickWidget->source();
+	ui.quickWidget->setSource({});
+	ui.quickWidget->engine()->clearComponentCache();
+	ui.quickWidget->setSource(Source);
+	ui.quickWidget->setStyleSheet(StyleManager->styleSheet());
+}
+
+
 
 void MainWindowPrivate::fillThemeMenu()
 {
@@ -104,6 +118,14 @@ void MainWindowPrivate::setSomeIcons()
     }
 }
 
+void MainWindowPrivate::setupQuickWidget()
+{
+    ui.quickWidget->engine()->setUrlInterceptor(
+        new acss::CQmlStyleUrlInterceptor(StyleManager));
+    ui.quickWidget->setStyleSheet(StyleManager->styleSheet());
+    ui.quickWidget->setSource(QUrl("qrc:/full_features/qml/simple_demo.qml"));
+}
+
 
 CMainWindow::CMainWindow(QWidget *parent)
     : QMainWindow(parent),
@@ -127,6 +149,7 @@ CMainWindow::CMainWindow(QWidget *parent)
     d->createThemeColorDockWidget();
     d->fillThemeMenu();
     d->setSomeIcons();
+    d->setupQuickWidget();
 }
 
 CMainWindow::~CMainWindow()
@@ -147,6 +170,7 @@ void CMainWindow::onStyleManagerStylesheetChanged()
 {
 	qApp->setStyleSheet(d->StyleManager->styleSheet());
 	d->updateThemeColorButtons();
+	d->updateQuickWidget();
 }
 
 

--- a/examples/full_features/mainwindow.ui
+++ b/examples/full_features/mainwindow.ui
@@ -41,7 +41,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>487</width>
+             <width>521</width>
              <height>388</height>
             </rect>
            </property>
@@ -87,7 +87,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>487</width>
+             <width>521</width>
              <height>388</height>
             </rect>
            </property>
@@ -99,7 +99,6 @@
              <widget class="QLabel" name="label_3">
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>
@@ -1117,6 +1116,115 @@
             <string>Page</string>
            </attribute>
            <layout class="QGridLayout" name="gridLayout_6">
+            <item row="0" column="1">
+             <widget class="QTreeWidget" name="treeWidget">
+              <column>
+               <property name="text">
+                <string>Material Tree</string>
+               </property>
+              </column>
+              <item>
+               <property name="text">
+                <string>Tree #1</string>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Subitem #1</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Subitem #2</string>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>New Subitem</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>New Item</string>
+                 </property>
+                </item>
+               </item>
+              </item>
+              <item>
+               <property name="text">
+                <string>Tree #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Subitem #4</string>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Subitem #41</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Subitem #42</string>
+                </property>
+               </item>
+              </item>
+              <item>
+               <property name="text">
+                <string>Subitem #5</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Tree #3</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Tree #4</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QListWidget" name="listWidget_2">
+              <property name="iconSize">
+               <size>
+                <width>64</width>
+                <height>64</height>
+               </size>
+              </property>
+              <property name="resizeMode">
+               <enum>QListView::Adjust</enum>
+              </property>
+              <property name="spacing">
+               <number>15</number>
+              </property>
+              <property name="viewMode">
+               <enum>QListView::IconMode</enum>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="sortingEnabled">
+               <bool>true</bool>
+              </property>
+              <item>
+               <property name="text">
+                <string>New Item</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>New Item</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>New Item</string>
+               </property>
+              </item>
+             </widget>
+            </item>
             <item row="0" column="0">
              <widget class="QSplitter" name="splitter">
               <property name="orientation">
@@ -1279,115 +1387,6 @@
               </widget>
              </widget>
             </item>
-            <item row="0" column="2">
-             <widget class="QListWidget" name="listWidget_2">
-              <property name="iconSize">
-               <size>
-                <width>64</width>
-                <height>64</height>
-               </size>
-              </property>
-              <property name="resizeMode">
-               <enum>QListView::Adjust</enum>
-              </property>
-              <property name="spacing">
-               <number>15</number>
-              </property>
-              <property name="viewMode">
-               <enum>QListView::IconMode</enum>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="sortingEnabled">
-               <bool>true</bool>
-              </property>
-              <item>
-               <property name="text">
-                <string>New Item</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>New Item</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>New Item</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QTreeWidget" name="treeWidget">
-              <column>
-               <property name="text">
-                <string>Material Tree</string>
-               </property>
-              </column>
-              <item>
-               <property name="text">
-                <string>Tree #1</string>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Subitem #1</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Subitem #2</string>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>New Subitem</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>New Item</string>
-                 </property>
-                </item>
-               </item>
-              </item>
-              <item>
-               <property name="text">
-                <string>Tree #2</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Subitem #4</string>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Subitem #41</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Subitem #42</string>
-                </property>
-               </item>
-              </item>
-              <item>
-               <property name="text">
-                <string>Subitem #5</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Tree #3</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Tree #4</string>
-               </property>
-              </item>
-             </widget>
-            </item>
             <item row="0" column="3">
              <widget class="QTableWidget" name="tableWidget">
               <property name="alternatingRowColors">
@@ -1493,6 +1492,25 @@
                 <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable</set>
                </property>
               </item>
+             </widget>
+            </item>
+            <item row="0" column="4">
+             <widget class="QQuickWidget" name="quickWidget">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="resizeMode">
+               <enum>QQuickWidget::SizeRootObjectToView</enum>
+              </property>
              </widget>
             </item>
            </layout>
@@ -2123,10 +2141,10 @@
       <widget class="QTextEdit" name="textEdit">
        <property name="html">
         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:6px; margin-bottom:6px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Noto Sans';&quot;&gt;textEdit Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:6px; margin-bottom:6px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;textEdit Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>
@@ -2242,6 +2260,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QQuickWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">QtQuickWidgets/QQuickWidget</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/examples/full_features/qml/simple_demo.qml
+++ b/examples/full_features/qml/simple_demo.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Page {
+    width: 100
+    height: 250
+
+    Column {
+        CheckBox {
+            id: checkBox
+
+            indicator: Rectangle {
+                implicitHeight: 26
+                implicitWidth: 26
+                x: checkBox.leftPadding
+                y: checkBox.height / 2 - height / 2
+                Image {
+                    source: checkBox.checked ? "icon:/primary/checkbox_checked.svg" :
+                                               "icon:/primary/checkbox_unchecked.svg"
+                    cache: false
+                }
+            }
+        }
+            Repeater {
+                model: 3
+                RadioButton {
+                    id: radioButton
+
+                    indicator: Rectangle {
+                        implicitHeight: 26
+                        implicitWidth: 26
+                        x: radioButton.leftPadding
+                        y: radioButton.height / 2 - height / 2
+                        Image {
+                            source: radioButton.checked ?
+                                        "icon:/primary/radiobutton_checked.svg" :
+                                        "icon:/primary/radiobutton_unchecked.svg"
+                            cache: false
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/src/QmlStyleUrlInterceptor.cpp
+++ b/src/QmlStyleUrlInterceptor.cpp
@@ -1,0 +1,39 @@
+//============================================================================
+/// \file   QmlStyleUrlInterceptor.cpp
+/// \author Florian Meinicke (florian.meinicke@t-online.de)
+/// \date   06.01.2022
+/// \brief  Implementation of the CQmlStyleUrlInterceptor class.
+//============================================================================
+
+//============================================================================
+//                                  INCLUDES
+//============================================================================
+#include "QmlStyleUrlInterceptor.h"
+
+#include <QDebug>
+
+#include "StyleManager.h"
+
+namespace acss
+{
+//=============================================================================
+CQmlStyleUrlInterceptor::CQmlStyleUrlInterceptor(CStyleManager* StyleManager)
+    : m_StyleManager{StyleManager}
+{}
+
+//=============================================================================
+QUrl CQmlStyleUrlInterceptor::intercept(const QUrl& path, DataType type)
+{
+    if (type == UrlString && path.scheme() == "icon")
+    {
+        if (m_StyleManager)
+        {
+            return QUrl::fromLocalFile(m_StyleManager->currentStyleOutputPath()
+                                       + '/' + path.path());
+        }
+        qWarning() << "AdvancedStylesheet Error: CQmlStyleUrlInterceptor has no "
+                      "valid CStyleManager!";
+    }
+    return path;
+}
+}  // namespace acss

--- a/src/QmlStyleUrlInterceptor.h
+++ b/src/QmlStyleUrlInterceptor.h
@@ -1,0 +1,66 @@
+//============================================================================
+/// \file   QmlStyleUrlInterceptor.h
+/// \author Florian Meinicke (florian.meinicke@t-online.de)
+/// \date   06.01.2022
+/// \brief  Declaration of the CQmlStyleUrlInterceptor class.
+//============================================================================
+#ifndef ACSS_CQMLSTYLEURLINTERCEPTOR_H
+#define ACSS_CQMLSTYLEURLINTERCEPTOR_H
+
+//============================================================================
+//                                  INCLUDES
+//============================================================================
+#include <QQmlAbstractUrlInterceptor>
+
+namespace acss
+{
+class CStyleManager;
+
+/**
+ * @brief The CQmlStyleUrlInterceptor class provides a URL interceptor that can be
+ * set on a @c QQmlEngine so that the functionality of ACSS is available in QML as
+ * well.
+ *
+ * For example,
+ * @code
+ * auto StyleManager = new CStyleManager;
+ * //...
+ * QQuickWidget Widget;
+ * Widget.engine()->setUrlInterceptor(new CQmlStyleUrlInterceptor(StyleManager));
+ * @endcode
+ * Now you can use the "icon:" prefix in QML wherever you want to set an icon from
+ * the current style:
+ * @code
+ * import QtQuickControls 2.15
+ *
+ * Item {
+ *   ToolButton {
+ *     id: button
+ *     icon.source: "icon:/myicon.svg"
+ *   }
+ * }
+ * @endcode
+ * The @c CQmlStyleUrlInterceptor will intercept all URLs with the "icon:" prefix
+ * and turn them into absolute paths (with the help of the @c CStyleManager
+ * instance passed in the constructor) that can be understood by QML.
+ */
+class CQmlStyleUrlInterceptor : public QQmlAbstractUrlInterceptor
+{
+public:
+    /**
+     * @brief Constructor
+     *
+     * @param StyleManager The Style Manager to use for resolving the URLs
+     */
+    CQmlStyleUrlInterceptor(CStyleManager* StyleManager);
+
+    // implements QQmlAbstractUrlInterceptor ---------------------------------
+    QUrl intercept(const QUrl& path, DataType type) override;
+
+private:
+    CStyleManager* m_StyleManager;
+};
+
+}  // namespace acss
+
+#endif  // ACSS_CQMLSTYLEURLINTERCEPTOR_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,7 @@ TARGET = $$qtLibraryTarget(qtadvancedcss)
 DEFINES += QT_DEPRECATED_WARNINGS
 TEMPLATE = lib
 DESTDIR = $${ACSS_OUT_ROOT}/lib
-QT += core gui widgets
+QT += core gui widgets qml
 
 !acssBuildStatic {
 	CONFIG += shared
@@ -30,10 +30,12 @@ windows {
 #RESOURCES += ads.qrc
 
 HEADERS += \
+	QmlStyleUrlInterceptor.h \
 	StyleManager.h
 
 
 SOURCES += \
+	QmlStyleUrlInterceptor.cpp \
 	StyleManager.cpp
 
 


### PR DESCRIPTION
This PR adds support for using ACSS in QML.

Trying to use ACSS in QML as you would in C++ does not work out of the box. I.e. the following doesn't work:
```qml
        // ...
        Image {
            source: checkBox.checked ? "icon:/primary/checkbox_checked.svg" :
                                       "icon:/primary/checkbox_unchecked.svg"
        }
```

This PR introduces a new class called `CQmlStyleUrlInterceptor` class which intercepts all requests from QML to resolve a certain URL. If the class encounters a URL starting with "icon" it uses the `CStyleManager` to translate that into an absolute file system path that can be understood by QML.

The `full_features` example was updated as well to showcase how one would use ACSS with QML.

An important thing to note is that wherever you want to use icons from ACSS you need to set `Image.cache: false`. Otherwise, QML will cache the images and won't show an immediate update if the theme has been changed.